### PR TITLE
Add user to docker group and add show git info at start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # OS2Display
 
+## Links to repositories and Docker images
+
+OS2 docker images used in this project:
+
+- [os2display-admin-client](https://hub.docker.com/r/os2display/os2display-admin-client)
+- [os2display-client](https://hub.docker.com/r/os2display/os2display-client)
+- [os2display-api-service-nginx](https://hub.docker.com/r/os2display/os2display-api-service-nginx)
+- [os2display/os2display-api-service](https://hub.docker.com/r/os2display/os2display-api-service)
+
+OS2 github repositories used in this project:
+
+- [display-admin-client](https://github.com/os2display/display-admin-client)
+- [display-client](https://github.com/os2display/display-client)
+- [display-api-service](https://github.com/os2display/display-api-service)
+
 ## How to install OS2Display
 
 ### Custom .env file - "Automatic install"

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ source scripts/functions.sh
 ENV_FILE="./.env"
 DB_TEST_COUNT=15
 
+# Check if user is in docker group
+check_docker_group
+
 # Install all the dependencies, if missing.
 install_dependencies
 

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@ source scripts/functions.sh
 ENV_FILE="./.env"
 DB_TEST_COUNT=15
 
+# Inform git information
+check_git_branch
+sleep 2 # Sleep for people to be able to read above information.
+
 # Check if user is in docker group
 check_docker_group
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -161,7 +161,6 @@ sudo_create_admin () {
 ## Checks whether or not the current user is in the docker group or not
 #---
 check_docker_group () {
-
 	echo "Checking if user is in docker group".
 	echo "If you have just added your user in the docker group in the currently running session,"
 	echo "you may want to refresh your session, e.g. by logging out and logging in again."
@@ -177,6 +176,18 @@ check_docker_group () {
 		sudo usermod -aG docker $(echo $USER)
 		exit 5
 	fi
+}
+
+#---
+## Check git branch
+#---
+check_git_branch () {
+	echo "##### GIT INFORMATION #####"
+	REMOTE=$(git remote get-url origin)
+	BRANCH=$(git rev-parse --abbrev-ref HEAD)
+	printf 'GIT BRANCH: %s\n' "$BRANCH"
+	printf 'GIT REMOTE: %s\n' "$REMOTE"
+	echo "###########################"
 }
 
 #---

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -161,6 +161,11 @@ sudo_create_admin () {
 ## Checks whether or not the current user is in the docker group or not
 #---
 check_docker_group () {
+
+	echo "Checking if user is in docker group".
+	echo "If you have just added your user in the docker group in the currently running session,"
+	echo "you may want to refresh your session, e.g. by logging out and logging in again."
+
 	# Get the output of the groups command and check if "docker" appears in the groups
 	DOCKER_GROUP=$(groups | sed 's/ /\n/g' | grep "docker")
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -328,9 +328,6 @@ install_dependencies () {
 					sudo apt install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker docker-compose-plugin -y -q
 					sudo systemctl enable docker containerd
 
-					# Check if the logged in user is in the docker group, and add them if they aren't.
-					check_docker_group
-
 				elif [[ "$DEP" = "certbot" ]]; then
 					sudo python3 -m venv /opt/certbot/
 					sudo /opt/certbot/bin/pip install --upgrade pip

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -370,6 +370,7 @@ initiate () {
 
 	# Making sure this folder is available for the right user and group
 	sudo docker compose exec --user root api chown -R deploy. /var/www/html/config/jwt
+	sudo docker compose exec --user root api mkdir /var/www/html/media
 	sudo docker compose exec --user root api chown -R deploy. /var/www/html/media
 	sudo docker compose exec --user root api mkdir /var/www/html/public/media/
 	sudo docker compose exec --user root api chown -R deploy. /var/www/html/public/media/
@@ -385,10 +386,10 @@ initiate () {
 	# Migrate database and import templates and screen layouts
 	migrate_and_import
 
-	docker compose exec client mkdir -p /var/www/html/client/
-	docker compose exec client ln -s /var/www/html/static /var/www/html/client/
-	docker compose exec client ln -s /var/www/html/config.json /var/www/html/client/
-	docker compose exec client ln -s /var/www/html/release.json /var/www/html/client/
+	sudo docker compose exec client mkdir -p /var/www/html/client/
+	sudo docker compose exec client ln -s /var/www/html/static /var/www/html/client/
+	sudo docker compose exec client ln -s /var/www/html/config.json /var/www/html/client/
+	sudo docker compose exec client ln -s /var/www/html/release.json /var/www/html/client/
 
 	# Ask if we want to create a tenant and administrator now or later?
 	read -rep $'Do you want to create a tenant and administrator now? (Y/N):' continue

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -110,7 +110,7 @@ migrate_and_import () {
 	sudo docker compose exec --user deploy api bin/console app:template:load https://raw.githubusercontent.com/os2display/display-templates/main/build/travel-config-main.json
 	sudo docker compose exec --user deploy api bin/console app:template:load https://raw.githubusercontent.com/os2display/display-templates/main/build/video-config-main.json
 
-	# Import screen layoyts
+	# Import screen layouts
 	printf "Importing screen layouts\n"
 	sudo docker compose exec --user deploy api bin/console app:screen-layouts:load --update --cleanup-regions https://raw.githubusercontent.com/os2display/display-templates/main/src/screen-layouts/full-screen.json
 	sudo docker compose exec --user deploy api bin/console app:screen-layouts:load --update --cleanup-regions https://raw.githubusercontent.com/os2display/display-templates/main/src/screen-layouts/three-boxes-horizontal.json


### PR DESCRIPTION
This adds the user running the install script to the docker group, and exits the script so the user can refresh their console session by e.g. logging out and logging in again.

On top of that, this shows git branch and remote at the beginning of install.